### PR TITLE
在播放视频的时候截图弹窗会有沙箱冲突，为保证通用性，这里建议采用透明度。

### DIFF
--- a/src/looselive/controls/dialog/Background.as
+++ b/src/looselive/controls/dialog/Background.as
@@ -15,15 +15,17 @@ package looselive.controls.dialog
 	{
 		public function Background(stage:Stage)
 		{
-			var background:BitmapData = new BitmapData(stage.stageWidth, stage.stageHeight, true, 0xFFcccccc);
-			var stageBackground:BitmapData = new BitmapData(stage.stageWidth, stage.stageHeight);
-				stageBackground.draw(stage);
+			var background:BitmapData = new BitmapData(stage.stageWidth, stage.stageHeight, true, 0xFF000000);
+			// var stageBackground:BitmapData = new BitmapData(stage.stageWidth, stage.stageHeight);
+			// stageBackground.draw(stage);
 			var rectangle:Rectangle = new Rectangle(0, 0, stage.stageWidth, stage.stageHeight);
 			var point:Point = new Point(0, 0);
 			var multiplier:uint = 120;
-			background.merge(stageBackground, rectangle, point, multiplier, multiplier, multiplier, multiplier);
+			// background.merge(stageBackground, rectangle, point, multiplier, multiplier, multiplier, multiplier);
 			background.applyFilter(background, rectangle, point, new BlurFilter(3, 3, 2));
-			addChild(new Bitmap(background));
+			var bitmap:Bitmap = new Bitmap(background);
+			bitmap.alpha = 0.5;
+			addChild(bitmap);
 		}
 	}
 }


### PR DESCRIPTION
SecurityError: Error #2123: 安全沙箱冲突,对NetStream使用BitmapData.draw()
